### PR TITLE
fix: secure folder thumbnail, view flicker, sort, other minor issues

### DIFF
--- a/app/src/main/java/com/kaii/photos/compose/grids/media/MediaItem.kt
+++ b/app/src/main/java/com/kaii/photos/compose/grids/media/MediaItem.kt
@@ -115,13 +115,18 @@ fun MediaItem(
 
         GlideImage(
             model = when {
-                isSecureMedia -> (item as PhotoLibraryUIModel.SecuredMedia).bytes?.getThumbnailIv()?.let {
-                    SecureInfo(
-                        iv = it,
-                        absolutePath = File(item.item.absolutePath).secureThumbnailImage(context).absolutePath,
-                        key = item.signature()
-                    )
-                }
+                isSecureMedia -> (item as PhotoLibraryUIModel.SecuredMedia).bytes
+                    ?.takeIf { it.size >= 32 }
+                    ?.getThumbnailIv()
+                    // all-zero iv means the thumbnail isn't ready; fall through to a null model -> placeholder
+                    ?.takeIf { iv -> iv.any { it.toInt() != 0 } }
+                    ?.let {
+                        SecureInfo(
+                            iv = it,
+                            absolutePath = File(item.item.absolutePath).secureThumbnailImage(context).absolutePath,
+                            key = item.signature()
+                        )
+                    }
 
                 item.item.isCloud -> ImmichInfo(
                     thumbnail = item.item.immichThumbnail!!,
@@ -144,8 +149,12 @@ fun MediaItem(
                 .clip(androidx.compose.foundation.shape.RoundedCornerShape(animatedItemCornerRadius))
         ) {
             if (isSecureMedia) {
-                it.signature(item.signature())
+                // never disk-cache decrypted secure thumbnails (plaintext at rest); bound the decode to
+                // the requested size like the non-secure branch
+                val secureRequest = it.signature(item.signature())
                     .diskCacheStrategy(DiskCacheStrategy.NONE)
+                if (thumbnailSettings().second != 0) secureRequest.override(thumbnailSettings().second)
+                else secureRequest
             } else if (thumbnailSettings().second == 0) {
                 it.signature(item.signature())
                     .diskCacheStrategy(

--- a/app/src/main/java/com/kaii/photos/compose/single_photo/HorizontalImageList.kt
+++ b/app/src/main/java/com/kaii/photos/compose/single_photo/HorizontalImageList.kt
@@ -40,7 +40,6 @@ import com.bumptech.glide.load.engine.DiskCacheStrategy
 import com.bumptech.glide.load.resource.bitmap.DownsampleStrategy
 import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions.withCrossFade
 import com.bumptech.glide.load.resource.gif.GifDrawable
-import com.bumptech.glide.signature.ObjectKey
 import com.kaii.photos.R
 import com.kaii.photos.compose.app_bars.setBarVisibility
 import com.kaii.photos.compose.transformable
@@ -48,6 +47,7 @@ import com.kaii.photos.compose.videoplayer.VideoPlayer
 import com.kaii.photos.database.entities.MediaStoreData
 import com.kaii.photos.helpers.AnimationConstants
 import com.kaii.photos.helpers.SingleViewConstants
+import com.kaii.photos.helpers.secureThumbnailImage
 import com.kaii.photos.helpers.motion_photo.rememberMotionPhoto
 import com.kaii.photos.helpers.paging.PhotoLibraryUIModel
 import com.kaii.photos.helpers.scrolling.SinglePhotoScrollState
@@ -56,13 +56,14 @@ import com.kaii.photos.mediastore.ImmichInfo
 import com.kaii.photos.mediastore.MediaType
 import com.kaii.photos.mediastore.SecureInfo
 import com.kaii.photos.mediastore.getIv
+import com.kaii.photos.mediastore.getThumbnailIv
 import com.kaii.photos.mediastore.signature
 import me.saket.telephoto.zoomable.ZoomSpec
 import me.saket.telephoto.zoomable.ZoomableState
 import me.saket.telephoto.zoomable.glide.ZoomableGlideImage
 import me.saket.telephoto.zoomable.rememberZoomableImageState
 import me.saket.telephoto.zoomable.rememberZoomableState
-import kotlin.time.Clock
+import java.io.File
 
 @androidx.annotation.OptIn(UnstableApi::class)
 @OptIn(ExperimentalGlideComposeApi::class)
@@ -92,7 +93,9 @@ fun HorizontalImageList(
         state = state,
         verticalAlignment = Alignment.CenterVertically,
         pageSpacing = 8.dp,
-        // beyondViewportPageCount = 5, // TODO: check this
+        // preload one page either side so the next/previous secure image starts decrypting before the
+        // swipe settles. kept at 1 (not 5) since each secure neighbour is a full-file decrypt
+        beyondViewportPageCount = 1,
         key = items.itemKey { it.itemKey() },
         snapPosition = SnapPosition.Center,
         userScrollEnabled = !scrollState.privacyMode && !scrollState.videoLock,
@@ -200,6 +203,31 @@ fun HorizontalImageList(
                     }
                 }
 
+                val context = LocalContext.current
+
+                // cheap base layer for the secure viewer: the small pre-stored encrypted thumbnail (same
+                // model the grid uses, so it's likely already in glide's memory cache). gated on a ready
+                // (non-zero) iv and an existing file; null -> the full-file model is used as the base
+                val glideThumbnailModel = remember(media) {
+                    if (!isSecuredMedia) null
+                    else (media as PhotoLibraryUIModel.SecuredMedia).bytes
+                        ?.takeIf { it.size >= 32 }
+                        ?.getThumbnailIv()
+                        ?.takeIf { iv -> iv.any { b -> b.toInt() != 0 } }
+                        ?.let { thumbIv ->
+                            val thumbFile = File(media.item.absolutePath).secureThumbnailImage(context)
+                            if (thumbFile.exists()) {
+                                SecureInfo(
+                                    iv = thumbIv,
+                                    absolutePath = thumbFile.absolutePath,
+                                    key = media.signature()
+                                )
+                            } else {
+                                null
+                            }
+                        }
+                }
+
                 if (blurViews) {
                     var targetAlpha by remember { mutableFloatStateOf(0f) }
                     val animatedAlpha by animateFloatAsState(
@@ -243,6 +271,7 @@ fun HorizontalImageList(
                         glideImageView = @Composable { modifier ->
                             GlideView(
                                 model = glideModel,
+                                thumbnailModel = glideThumbnailModel,
                                 item = media.item,
                                 zoomableState = zoomableState,
                                 window = window,
@@ -256,6 +285,7 @@ fun HorizontalImageList(
                 } else {
                     GlideView(
                         model = glideModel,
+                        thumbnailModel = glideThumbnailModel,
                         item = media.item,
                         zoomableState = zoomableState,
                         window = window,
@@ -290,7 +320,8 @@ fun GlideView(
     modifier: Modifier = Modifier,
     useCache: Boolean,
     disableSetBarVisibility: Boolean = false,
-    isHidden: Boolean = false
+    isHidden: Boolean = false,
+    thumbnailModel: Any? = null
 ) {
     val context = LocalContext.current
     val state = rememberZoomableImageState(zoomableState = zoomableState)
@@ -325,13 +356,16 @@ fun GlideView(
         modifier = modifier
             .fillMaxSize()
     ) {
+        // never disk-cache secure media even if "cache thumbnails" is on: the disk cache would hold the
+        // decrypted bytes as plaintext. the grid already hardcodes NONE for secure; mirror that here
+        val isSecure = model is SecureInfo
         val request = it
-            .signature(
-                if (useCache) item.signature()
-                else ObjectKey(Clock.System.now().toEpochMilliseconds())
-            )
+            // stable per-item signature. the old ObjectKey(now()) branch (used when !useCache, the secure
+            // default) changed every recomposition, busting the memory cache and forcing a full re-decrypt
+            // -> the jitter / low-quality flash. disk caching is still governed by diskCacheStrategy below
+            .signature(item.signature())
             .downsample(DownsampleStrategy.FIT_CENTER)
-            .diskCacheStrategy(if (useCache) DiskCacheStrategy.ALL else DiskCacheStrategy.NONE)
+            .diskCacheStrategy(if (useCache && !isSecure) DiskCacheStrategy.ALL else DiskCacheStrategy.NONE)
             .error(
                 when {
                     isHidden -> R.drawable.empty_image
@@ -344,11 +378,14 @@ fun GlideView(
             .thumbnail(
                 Glide.with(context)
                     .load(
-                        if (model is ImmichInfo) model.copy(useThumbnail = true)
-                        else model
+                        // prefer the cheap small thumbnail so the base layer isn't a second full-file
+                        // decrypt; fall back to the full model when none was supplied
+                        thumbnailModel
+                            ?: if (model is ImmichInfo) model.copy(useThumbnail = true)
+                            else model
                     )
                     .signature(item.signature())
-                    .diskCacheStrategy(if (useCache) DiskCacheStrategy.ALL else DiskCacheStrategy.NONE)
+                    .diskCacheStrategy(if (useCache && !isSecure) DiskCacheStrategy.ALL else DiskCacheStrategy.NONE)
                     .override(windowSize.width, windowSize.height)
             )
             .transition(withCrossFade(if (isHidden) 250 else 100))

--- a/app/src/main/java/com/kaii/photos/helpers/EncryptionManager.kt
+++ b/app/src/main/java/com/kaii/photos/helpers/EncryptionManager.kt
@@ -27,35 +27,47 @@ object EncryptionManager {
 
     private const val TRANSFORMATION = "$ENCRYPTION_ALGORITHM/$ENCRYPTION_BLOCK_MODE/$ENCRYPTION_PADDING"
 
+    // the keystore key never changes once made, so cache it instead of a keystore round-trip per decrypt
+    @Volatile
+    private var cachedKey: SecretKey? = null
+
     private fun getOrCreateSecretKey(): SecretKey {
-        val keystore = KeyStore.getInstance(KEYSTORE)
-        keystore.load(null)
+        cachedKey?.let { return it }
 
-        // if key already exists just return it
-        keystore.getKey(KEY_NAME, null)?.let { possiblePreviousKey ->
-            return possiblePreviousKey as SecretKey
+        return synchronized(this) {
+            // double-checked: another thread may have populated the cache while we waited on the lock
+            cachedKey?.let { return@synchronized it }
+
+            val keystore = KeyStore.getInstance(KEYSTORE)
+            keystore.load(null)
+
+            // if key already exists just reuse it, otherwise create it once
+            val key = (keystore.getKey(KEY_NAME, null) as? SecretKey) ?: run {
+                val keyGenParams =
+                    KeyGenParameterSpec.Builder(
+                        KEY_NAME,
+                        KeyProperties.PURPOSE_DECRYPT or KeyProperties.PURPOSE_ENCRYPT
+                    )
+                        .setBlockModes(ENCRYPTION_BLOCK_MODE)
+                        .setEncryptionPaddings(ENCRYPTION_PADDING)
+                        .setUserAuthenticationRequired(false)
+                        .setKeySize(KEY_SIZE)
+                        .setInvalidatedByBiometricEnrollment(false)
+                        .setRandomizedEncryptionRequired(true)
+                        .build()
+
+                val keyGenerator = KeyGenerator.getInstance(
+                    ENCRYPTION_ALGORITHM,
+                    KEYSTORE
+                )
+                keyGenerator.init(keyGenParams)
+
+                keyGenerator.generateKey()
+            }
+
+            cachedKey = key
+            key
         }
-
-        val keyGenParams =
-            KeyGenParameterSpec.Builder(
-                KEY_NAME,
-                KeyProperties.PURPOSE_DECRYPT or KeyProperties.PURPOSE_ENCRYPT
-            )
-                .setBlockModes(ENCRYPTION_BLOCK_MODE)
-                .setEncryptionPaddings(ENCRYPTION_PADDING)
-                .setUserAuthenticationRequired(false)
-                .setKeySize(KEY_SIZE)
-                .setInvalidatedByBiometricEnrollment(false)
-                .setRandomizedEncryptionRequired(true)
-                .build()
-
-        val keyGenerator = KeyGenerator.getInstance(
-            ENCRYPTION_ALGORITHM,
-            KEYSTORE
-        )
-        keyGenerator.init(keyGenParams)
-
-        return keyGenerator.generateKey()
     }
 
     private fun writeToOutputStream(

--- a/app/src/main/java/com/kaii/photos/helpers/ImageFunctions.kt
+++ b/app/src/main/java/com/kaii/photos/helpers/ImageFunctions.kt
@@ -139,16 +139,26 @@ suspend fun moveMediaToSecureFolder(
     applicationDatabase: MediaDatabase,
     onDone: () -> Unit
 ) = withContext(Dispatchers.IO) {
-    val lastModified = System.currentTimeMillis()
+    // sort the batch newest-first; the incoming set is unordered so don't trust iteration order.
+    // videos can report dateTaken == 0, so fall back to dateModified then absolutePath
+    val ordered = list.sortedWith(
+        compareByDescending<MediaStoreData> { it.dateTaken }
+            .thenByDescending { it.dateModified }
+            .thenByDescending { it.absolutePath }
+    )
+
+    // the secure grid sorts by each encrypted file's lastModified (truncated to whole seconds via /1000),
+    // so stamp destinations 1000ms apart, all above the highest existing mtime, to keep the batch order
+    // and float the most recently secured items to the top
+    val existingMaxMtime = File(context.appSecureFolderDir).listFiles()?.maxOfOrNull { it.lastModified() } ?: 0L
+    val baseModified = maxOf(System.currentTimeMillis(), existingMaxMtime + ordered.size * 1000L)
+
     val metadataRetriever = MediaMetadataRetriever()
 
-    list.forEach { mediaItem ->
+    ordered.forEachIndexed { index, mediaItem ->
         val fileToBeHidden = File(mediaItem.absolutePath)
         val copyToPath = context.appSecureFolderDir + "/" + fileToBeHidden.name
         try {
-            // set last modified so item shows up in correct place in locked folder
-            fileToBeHidden.setLastModified(lastModified)
-
             val destinationFile = File(copyToPath)
 
             context.contentResolver.setDateForMedia(
@@ -164,6 +174,10 @@ suspend fun moveMediaToSecureFolder(
                     fileToBeHidden.inputStream(),
                     destinationFile.outputStream()
                 )
+
+            // stamp the encrypted file (what the grid sorts by) with this item's slot, newest = highest.
+            // must run after the encrypt above sets its own write-time mtime, else it gets overwritten
+            destinationFile.setLastModified(baseModified - index * 1000L)
 
             applicationDatabase.securedItemEntityDao().insertEntity(
                 SecuredItemEntity(
@@ -198,6 +212,9 @@ suspend fun moveMediaToSecureFolder(
                     .submit()
                     .get()
 
+                // passing secureVideoThumbnailImage for an image is intentional: addEncryptedThumbnail
+                // re-applies secureThumbnailImage() and both collapse to the same secure_thumbnail_cache
+                // png the grid reads. don't "simplify" to destinationFile without also changing that
                 SecureRepository.addEncryptedThumbnail(
                     context = context,
                     thumbnail = thumbnail,

--- a/app/src/main/java/com/kaii/photos/models/GlideAppModule.kt
+++ b/app/src/main/java/com/kaii/photos/models/GlideAppModule.kt
@@ -126,12 +126,25 @@ class DecryptedThumbnailFetcher(
 ) : DataFetcher<InputStream> {
     override fun loadData(priority: Priority, callback: DataFetcher.DataCallback<in InputStream>) {
         try {
+            // all-zero iv means the thumbnail isn't ready yet; decrypting with it gives garbage, so
+            // fail cleanly and let glide show the placeholder + retry instead of a half-decoded image
+            if (item.iv.isEmpty() || item.iv.all { it.toInt() == 0 }) {
+                callback.onLoadFailed(IllegalStateException("secure thumbnail IV not ready for ${item.absolutePath}"))
+                return
+            }
+
             val encryptedBytes = File(item.absolutePath).readBytes()
 
             val decryptedBytes = EncryptionManager.decryptBytes(
                 bytes = encryptedBytes,
                 iv = item.iv
             )
+
+            // empty decrypt means corrupt/missing data; fail rather than hand glide an empty stream
+            if (decryptedBytes.isEmpty()) {
+                callback.onLoadFailed(IllegalStateException("secure decrypt produced no data for ${item.absolutePath}"))
+                return
+            }
 
             val inputStream = ByteArrayInputStream(decryptedBytes)
 

--- a/app/src/main/java/com/kaii/photos/repositories/SecureRepository.kt
+++ b/app/src/main/java/com/kaii/photos/repositories/SecureRepository.kt
@@ -28,6 +28,7 @@ import com.kaii.photos.helpers.secureThumbnailImage
 import com.kaii.photos.helpers.secureVideoThumbnailImage
 import com.kaii.photos.mediastore.LAVENDER_FILE_PROVIDER_AUTHORITY
 import com.kaii.photos.mediastore.MediaType
+import com.kaii.photos.mediastore.getThumbnailIv
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -38,6 +39,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.withContext
 import java.io.ByteArrayOutputStream
 import java.io.File
@@ -103,16 +105,40 @@ class SecureRepository(
 
     private val secureFolder = File(appContext.appSecureFolderDir)
 
+    private val repoScope = scope
+
+    // load() does a read-modify-write on items.value, so concurrent calls (init, the FileObserver firing
+    // once per file during a batch secure, the post-verify reload) used to lost-update each other and
+    // freeze a not-ready zero-iv row. serialise load() and coalesce bursts: while one runs, extra
+    // requests just set a rerun flag instead of spawning more coroutines
+    private val loadMutex = Mutex()
+    @Volatile
+    private var loadQueued = false
+
+    private fun requestLoad(context: Context) {
+        repoScope.launch { runLoadCoalesced(context) }
+    }
+
+    private suspend fun runLoadCoalesced(context: Context) {
+        loadQueued = true
+        if (!loadMutex.tryLock()) return // a load is already active; it will observe loadQueued and rerun
+        try {
+            while (loadQueued) {
+                loadQueued = false
+                load(context)
+            }
+        } finally {
+            loadMutex.unlock()
+        }
+    }
+
     private val fileObserver =
         object : FileObserver(File(appContext.appSecureFolderDir), CREATE or DELETE or MODIFY or MOVED_TO or MOVED_FROM) {
             override fun onEvent(event: Int, path: String?) {
                 // doesn't matter what event type just refresh
                 if (path != null) {
                     _fileList.value = secureFolder.listFiles()
-
-                    scope.launch {
-                        load(context = appContext)
-                    }
+                    requestLoad(appContext)
                 }
             }
         }
@@ -140,7 +166,7 @@ class SecureRepository(
 
     init {
         scope.launch {
-            load(context)
+            runLoadCoalesced(context)
         }
 
         scope.launch {
@@ -187,9 +213,29 @@ class SecureRepository(
         val metadataRetriever = MediaMetadataRetriever()
 
         snapshot.forEach { file ->
-            // if file is already processed, skip processing it
-            if (mediaStoreData.any { it.item.absolutePath == file.absolutePath }) {
-                return@forEach
+            // self-healing skip: only keep an already-processed item if its cached thumbnail iv still
+            // matches the db. if not (it was the zero not-ready sentinel, or the thumbnail was rebuilt
+            // after a cacheDir eviction with a fresh iv) drop it and rebuild below. previously this
+            // unconditionally skipped, freezing a broken thumbnail until app restart
+            val existingIndex = mediaStoreData.indexOfFirst { it.item.absolutePath == file.absolutePath }
+            if (existingIndex != -1) {
+                val dbThumbnailIv = dao.getIvFromSecuredPath(file.secureThumbnailImage(context).absolutePath)
+                val cachedThumbnailIv = mediaStoreData[existingIndex].bytes
+                    ?.takeIf { it.size >= 32 }
+                    ?.getThumbnailIv()
+                val cachedIsNotReady = cachedThumbnailIv != null && cachedThumbnailIv.all { it.toInt() == 0 }
+                val healthy =
+                    if (dbThumbnailIv == null) {
+                        // no thumbnail yet: keep the not-ready row as-is so we don't re-probe the item on
+                        // every FileObserver event during a batch. verifyThumbnails will generate it and
+                        // reload, after which dbThumbnailIv is non-null and the else branch rebuilds it
+                        cachedIsNotReady
+                    } else {
+                        cachedThumbnailIv != null && dbThumbnailIv.contentEquals(cachedThumbnailIv)
+                    }
+
+                if (healthy) return@forEach
+                mediaStoreData.removeAt(existingIndex)
             }
 
             val mimeType = Files.probeContentType(Path(file.absolutePath))
@@ -268,10 +314,15 @@ class SecureRepository(
     private suspend fun verifyThumbnails(context: Context) = withContext(Dispatchers.IO) {
         val snapshot = _fileList.value ?: return@withContext
 
+        var generatedAny = false
+
         snapshot.forEach { file ->
             val thumbnail = file.secureThumbnailImage(context)
 
-            if (dao.getIvFromSecuredPath(thumbnail.absolutePath) != null) return@forEach
+            // regenerate if the iv row is missing OR the cached png is gone. the thumbnail cache lives
+            // in cacheDir, which the OS can purge under storage pressure, leaving a dangling iv row that
+            // would otherwise never be rebuilt
+            if (dao.getIvFromSecuredPath(thumbnail.absolutePath) != null && thumbnail.exists()) return@forEach
 
             val mimeType = Files.probeContentType(Path(file.absolutePath))
             val type =
@@ -284,7 +335,12 @@ class SecureRepository(
             } else {
                 addImageThumbnail(file.secureVideoThumbnailImage(context), context)
             }
+            generatedAny = true
         }
+
+        // refresh the listing so items holding a not-ready (zero) iv pick up their real iv via the
+        // self-healing skip in load(). single coalesced reload, not one per file
+        if (generatedAny) runLoadCoalesced(context)
     }
 
     private suspend fun addImageThumbnail(

--- a/app/src/main/java/com/kaii/photos/repositories/SecureRepository.kt
+++ b/app/src/main/java/com/kaii/photos/repositories/SecureRepository.kt
@@ -73,12 +73,9 @@ class SecureRepository(
 
             val secureThumbnail = file.secureThumbnailImage(context)
             try {
-                secureThumbnail
-                    .outputStream()
-                    .let {
-                        if (encrypted.size <= 8 * 1024) it.write(encrypted)
-                        else it.buffered().write(encrypted)
-                    }
+                // use{} flushes and closes the stream; the old .let{} leaked the fd and a
+                // never-flushed buffered stream could drop the trailing bytes
+                secureThumbnail.outputStream().use { it.write(encrypted) }
             } catch (e: IOException) {
                 Log.d(TAG, e.toString())
                 e.printStackTrace()


### PR DESCRIPTION
Hi, thank you for the amazing app, using it daily. Here're some fixes to the issues that were bugging me. Commits should be easy to navigate if you decide to pick and choose only some of the fixes.

A list of fixes:
  - Thumbnails no longer flicker/jitter or flash low-quality when swiping through
  secured photos
  - Newly secured photos keep their original gallery order instead of getting shuffled
  - Broken thumbnails (from a not-ready state or the OS clearing the cache) now repair
  themselves instead of staying broken until restart
  - Faster secure grid scrolling by caching the encryption key instead of re-fetching it
  for every thumbnail
  - Plus a couple of smaller correctness fixes (cleanly handling not-ready thumbnails,
  and properly closing the thumbnail file stream)