### PR TITLE
fix: iv recovery fallback and more

### DIFF
--- a/app/src/main/java/com/kaii/photos/compose/single_photo/HorizontalImageList.kt
+++ b/app/src/main/java/com/kaii/photos/compose/single_photo/HorizontalImageList.kt
@@ -387,7 +387,9 @@ fun GlideView(
             .diskCacheStrategy(if (useCache && !isSecure) DiskCacheStrategy.ALL else DiskCacheStrategy.NONE)
             .error(
                 when {
-                    isHidden -> R.drawable.empty_image
+                    // secure full-image decode failed: fall back to the working thumbnail rather than
+                    // the blank empty_image; broken_image only when there's no thumbnail
+                    isHidden -> thumbnailModel ?: R.drawable.broken_image
 
                     model is ImmichInfo -> model.copy(useThumbnail = true)
 

--- a/app/src/main/java/com/kaii/photos/helpers/SecureIvRecovery.kt
+++ b/app/src/main/java/com/kaii/photos/helpers/SecureIvRecovery.kt
@@ -33,6 +33,13 @@ object SecureIvRecovery {
     /** securedPaths that failed recovery this session, so we don't re-probe them on every load/open. */
     private val unrecoverable = ConcurrentHashMap.newKeySet<String>()
 
+    /**
+     * securedPaths whose stored 16-byte iv already passed [ivProducesValidHeader] this session. A secure
+     * file's content and iv are immutable once written, so a pass stays valid - cache it so reprocessing
+     * the same item (e.g. after a thumbnail rebuild) doesn't re-read 32 bytes and re-init a Cipher.
+     */
+    private val verifiedIvs = ConcurrentHashMap.newKeySet<String>()
+
     /** [recover] then persist the result so future operations skip recovery. Off-main-thread only. */
     suspend fun recoverAndPersist(
         context: Context,
@@ -149,6 +156,7 @@ object SecureIvRecovery {
      */
     fun ivProducesValidHeader(securedFile: File, iv: ByteArray, mimeType: String?): Boolean {
         if (iv.size != 16) return true
+        if (securedFile.absolutePath in verifiedIvs) return true
         val magic = magicFor(mimeType) ?: return true
 
         val head = try {
@@ -159,7 +167,11 @@ object SecureIvRecovery {
         } ?: return true
 
         val firstBlock = EncryptionManager.decryptFirstBlock(head, iv) ?: return true
-        return headerMatchesMagic(firstBlock, magic)
+        // only cache a genuine magic match; the early `return true`s above are "can't check, trust it"
+        // (transient read/decrypt failures included) and must stay retryable
+        return headerMatchesMagic(firstBlock, magic).also {
+            if (it) verifiedIvs.add(securedFile.absolutePath)
+        }
     }
 
     /** Pure: does [firstBlock] begin with every byte of [magic]? Exposed for unit testing. */
@@ -169,14 +181,23 @@ object SecureIvRecovery {
         return true
     }
 
-    /** Invariant leading bytes per gated format, or null when we don't gate the format. */
+    /**
+     * Invariant leading bytes per gated format, or null when we don't gate the format. Returns a fresh
+     * copy each call so the shared constant instances can't be mutated through this public accessor.
+     *
+     * mp4/mov are deliberately ungated: their first bytes are a box size, not a magic, so there's nothing
+     * cheap to check at offset 0.
+     */
     fun magicFor(mimeType: String?): ByteArray? {
         val m = mimeType?.lowercase() ?: return null
         return when {
             m.contains("png") -> PNG_MAGIC
             m.contains("jpeg") || m.contains("jpg") -> JPEG_MAGIC
+            m.contains("webp") -> WEBP_MAGIC
+            m.contains("gif") -> GIF_MAGIC
+            m.contains("webm") -> WEBM_MAGIC
             else -> null
-        }
+        }?.copyOf()
     }
 
     private val JPEG_MAGIC = byteArrayOf(0xFF.toByte(), 0xD8.toByte(), 0xFF.toByte())
@@ -184,6 +205,15 @@ object SecureIvRecovery {
     private val PNG_MAGIC = byteArrayOf(
         0x89.toByte(), 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A
     )
+
+    /** "RIFF" container tag; bytes 4-7 are a varying size, so we only gate the invariant prefix. */
+    private val WEBP_MAGIC = byteArrayOf(0x52, 0x49, 0x46, 0x46)
+
+    /** "GIF8", invariant across the 87a/89a versions. */
+    private val GIF_MAGIC = byteArrayOf(0x47, 0x49, 0x46, 0x38)
+
+    /** EBML magic that opens every Matroska/WebM stream. */
+    private val WEBM_MAGIC = byteArrayOf(0x1A, 0x45, 0xDF.toByte(), 0xA3.toByte())
 
     private enum class Kind { PNG, JPEG, VIDEO, IMAGE_OTHER }
 
@@ -211,8 +241,11 @@ object SecureIvRecovery {
         }
     }
 
-    /** Smallest power-of-two sample size that brings both dimensions at/below [target]. */
-    private fun computeInSampleSize(width: Int, height: Int, target: Int): Int {
+    /**
+     * Smallest power-of-two sample size that brings both dimensions at/below [target]. `internal`
+     * (not private) so unit tests in this module can exercise the arithmetic directly.
+     */
+    internal fun computeInSampleSize(width: Int, height: Int, target: Int): Int {
         var sample = 1
         while (width / (sample * 2) >= target && height / (sample * 2) >= target) {
             sample *= 2

--- a/app/src/main/java/com/kaii/photos/helpers/SecureIvRecovery.kt
+++ b/app/src/main/java/com/kaii/photos/helpers/SecureIvRecovery.kt
@@ -141,22 +141,83 @@ object SecureIvRecovery {
         return null
     }
 
+    /**
+     * Cheap trust check for a stored 16-byte IV: decrypt the first ciphertext block and compare it to
+     * the format's magic bytes. In CBC a wrong IV corrupts only those leading bytes, so this catches a
+     * valid-length-but-wrong IV without a full-file decrypt. Returns true (trust it) for formats with no
+     * magic we gate on, a non-16-byte IV, or an unreadable file; false means the caller should re-recover.
+     */
+    fun ivProducesValidHeader(securedFile: File, iv: ByteArray, mimeType: String?): Boolean {
+        if (iv.size != 16) return true
+        val magic = magicFor(mimeType) ?: return true
+
+        val head = try {
+            securedFile.inputStream().use { s -> ByteArray(32).takeIf { s.read(it) >= 32 } }
+        } catch (e: Throwable) {
+            Log.e(TAG, "ivProducesValidHeader: read failed for ${securedFile.name}", e)
+            null
+        } ?: return true
+
+        val firstBlock = EncryptionManager.decryptFirstBlock(head, iv) ?: return true
+        return headerMatchesMagic(firstBlock, magic)
+    }
+
+    /** Pure: does [firstBlock] begin with every byte of [magic]? Exposed for unit testing. */
+    fun headerMatchesMagic(firstBlock: ByteArray, magic: ByteArray): Boolean {
+        if (firstBlock.size < magic.size) return false
+        for (i in magic.indices) if (firstBlock[i] != magic[i]) return false
+        return true
+    }
+
+    /** Invariant leading bytes per gated format, or null when we don't gate the format. */
+    fun magicFor(mimeType: String?): ByteArray? {
+        val m = mimeType?.lowercase() ?: return null
+        return when {
+            m.contains("png") -> PNG_MAGIC
+            m.contains("jpeg") || m.contains("jpg") -> JPEG_MAGIC
+            else -> null
+        }
+    }
+
+    private val JPEG_MAGIC = byteArrayOf(0xFF.toByte(), 0xD8.toByte(), 0xFF.toByte())
+
+    private val PNG_MAGIC = byteArrayOf(
+        0x89.toByte(), 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A
+    )
+
     private enum class Kind { PNG, JPEG, VIDEO, IMAGE_OTHER }
 
-    /** Decode-validate the reconstructed plaintext file (cheap bounds/metadata check, no full render). */
+    /** Validate the reconstructed plaintext file: full (downsampled) image decode, or video metadata. */
     private fun validates(context: Context, plaintext: File, kind: Kind): Boolean = when (kind) {
         Kind.VIDEO -> validatesVideo(plaintext)
         else -> validatesImage(plaintext)
     }
 
     private fun validatesImage(plaintext: File): Boolean {
+        // header-only bounds (inJustDecodeBounds) can pass on a wrong-IV candidate whose leading bytes
+        // still parse; force an actual downsampled decode so only real pixels are accepted.
         val opts = BitmapFactory.Options().apply { inJustDecodeBounds = true }
         return try {
             BitmapFactory.decodeFile(plaintext.absolutePath, opts)
-            opts.outWidth > 0 && opts.outHeight > 0
-        } catch (e: Exception) {
+            if (opts.outWidth <= 0 || opts.outHeight <= 0) return false
+
+            val decodeOpts = BitmapFactory.Options().apply {
+                inSampleSize = computeInSampleSize(opts.outWidth, opts.outHeight, 64)
+            }
+            val bitmap = BitmapFactory.decodeFile(plaintext.absolutePath, decodeOpts)
+            (bitmap != null).also { bitmap?.recycle() }
+        } catch (e: Throwable) {
             false
         }
+    }
+
+    /** Smallest power-of-two sample size that brings both dimensions at/below [target]. */
+    private fun computeInSampleSize(width: Int, height: Int, target: Int): Int {
+        var sample = 1
+        while (width / (sample * 2) >= target && height / (sample * 2) >= target) {
+            sample *= 2
+        }
+        return sample
     }
 
     private fun validatesVideo(plaintext: File): Boolean {

--- a/app/src/main/java/com/kaii/photos/repositories/SecureRepository.kt
+++ b/app/src/main/java/com/kaii/photos/repositories/SecureRepository.kt
@@ -286,7 +286,12 @@ class SecureRepository(
                 // pad corrupted/short ivs to 16 zero bytes so the [fileIv(16)][thumbnailIv(16)][path]
                 // layout holds and getThumbnailIv() doesn't read into the path bytes; recover first
                 val fileIv =
-                    if (iv != null && iv.size == 16) iv
+                    if (iv != null && iv.size == 16) {
+                        // a 16-byte iv can still be wrong (decrypts to garbage); re-check it against the
+                        // format magic and re-recover if bad rather than trusting size==16 forever
+                        if (SecureIvRecovery.ivProducesValidHeader(file, iv, mimeType)) iv
+                        else SecureIvRecovery.recoverAndPersist(context, file, mimeType, secureDao) ?: iv
+                    }
                     else if (iv != null) SecureIvRecovery.recoverAndPersist(context, file, mimeType, secureDao) ?: ByteArray(16)
                     else ByteArray(16)
                 fileIv + (thumbnailIv ?: ByteArray(16))

--- a/app/src/test/java/com/kaii/photos/SecureIvHeaderTest.kt
+++ b/app/src/test/java/com/kaii/photos/SecureIvHeaderTest.kt
@@ -2,6 +2,7 @@ package com.kaii.photos
 
 import com.kaii.photos.helpers.SecureIvRecovery
 import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -11,6 +12,9 @@ class SecureIvHeaderTest {
     private val jpegMagic = byteArrayOf(0xFF.toByte(), 0xD8.toByte(), 0xFF.toByte())
     private val pngMagic =
         byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A)
+    private val webpMagic = byteArrayOf(0x52, 0x49, 0x46, 0x46)
+    private val gifMagic = byteArrayOf(0x47, 0x49, 0x46, 0x38)
+    private val webmMagic = byteArrayOf(0x1A, 0x45, 0xDF.toByte(), 0xA3.toByte())
 
     @Test
     fun jpegFirstBlockWithCorrectMagicIsAccepted() {
@@ -55,12 +59,70 @@ class SecureIvHeaderTest {
     }
 
     @Test
-    fun magicForRecognisesJpegAndPngAndIgnoresOthers() {
+    fun magicForRecognisesGatedFormatsAndIgnoresUngatedOnes() {
         assertArrayEquals(jpegMagic, SecureIvRecovery.magicFor("image/jpeg"))
         assertArrayEquals(jpegMagic, SecureIvRecovery.magicFor("image/jpg"))
         assertArrayEquals(pngMagic, SecureIvRecovery.magicFor("image/png"))
-        assertNull(SecureIvRecovery.magicFor("video/webm"))
-        assertNull(SecureIvRecovery.magicFor("image/gif"))
+        assertArrayEquals(webpMagic, SecureIvRecovery.magicFor("image/webp"))
+        assertArrayEquals(gifMagic, SecureIvRecovery.magicFor("image/gif"))
+        assertArrayEquals(webmMagic, SecureIvRecovery.magicFor("video/webm"))
+        // mp4/mov have no byte-0 magic (size-prefixed boxes), so they stay ungated
+        assertNull(SecureIvRecovery.magicFor("video/mp4"))
+        assertNull(SecureIvRecovery.magicFor("video/quicktime"))
         assertNull(SecureIvRecovery.magicFor(null))
+    }
+
+    @Test
+    fun magicForReturnsDefensiveCopy() {
+        val first = SecureIvRecovery.magicFor("image/png")!!
+        first[0] = 0x00
+        // mutating the returned array must not corrupt the next caller's magic
+        assertArrayEquals(pngMagic, SecureIvRecovery.magicFor("image/png"))
+    }
+
+    @Test
+    fun webmFirstBlockWithCorrectMagicIsAccepted() {
+        val firstBlock = byteArrayOf(
+            0x1A, 0x45, 0xDF.toByte(), 0xA3.toByte(),
+            0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x1F,
+            0x42, 0x86.toByte(), 0x81.toByte(), 0x01
+        )
+        assertTrue(SecureIvRecovery.headerMatchesMagic(firstBlock, webmMagic))
+    }
+
+    @Test
+    fun computeInSampleSizeReturnsOneWhenAlreadyAtOrBelowTarget() {
+        // both dimensions already <= target: no downsampling
+        assertEquals(1, SecureIvRecovery.computeInSampleSize(64, 64, 64))
+        assertEquals(1, SecureIvRecovery.computeInSampleSize(40, 50, 64))
+        // just over target on one axis is still not enough to justify halving below target
+        assertEquals(1, SecureIvRecovery.computeInSampleSize(100, 100, 64))
+    }
+
+    @Test
+    fun computeInSampleSizeGrowsByPowersOfTwo() {
+        // loop steps while width/(sample*2) >= target AND height/(sample*2) >= target
+        // 128/2 = 64 >= 64 -> sample 2; 128/4 = 32 < 64 -> stop
+        assertEquals(2, SecureIvRecovery.computeInSampleSize(128, 128, 64))
+        // 256/2=128, /4=64 >=64 -> sample 4; /8=32 <64 -> stop
+        assertEquals(4, SecureIvRecovery.computeInSampleSize(256, 256, 64))
+        // 512 -> sample 8
+        assertEquals(8, SecureIvRecovery.computeInSampleSize(512, 512, 64))
+    }
+
+    @Test
+    fun computeInSampleSizeGatedByTheSmallerDimension() {
+        // wide but short: height short-circuits growth so the wide axis stays under-sampled
+        // 1000x50, target 64: 50/2 < 64 immediately -> sample stays 1
+        assertEquals(1, SecureIvRecovery.computeInSampleSize(1000, 50, 64))
+        // 1000x200, target 64: 200/2=100>=64 -> 2; 200/4=50<64 stop -> sample 2
+        assertEquals(2, SecureIvRecovery.computeInSampleSize(1000, 200, 64))
+    }
+
+    @Test
+    fun computeInSampleSizeHandlesZeroAndTinyDimensions() {
+        // a zero dimension can never satisfy width/(sample*2) >= target, so sample stays 1
+        assertEquals(1, SecureIvRecovery.computeInSampleSize(0, 0, 64))
+        assertEquals(1, SecureIvRecovery.computeInSampleSize(1, 1, 64))
     }
 }

--- a/app/src/test/java/com/kaii/photos/SecureIvHeaderTest.kt
+++ b/app/src/test/java/com/kaii/photos/SecureIvHeaderTest.kt
@@ -1,0 +1,66 @@
+package com.kaii.photos
+
+import com.kaii.photos.helpers.SecureIvRecovery
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SecureIvHeaderTest {
+    private val jpegMagic = byteArrayOf(0xFF.toByte(), 0xD8.toByte(), 0xFF.toByte())
+    private val pngMagic =
+        byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A)
+
+    @Test
+    fun jpegFirstBlockWithCorrectMagicIsAccepted() {
+        val firstBlock = byteArrayOf(
+            0xFF.toByte(), 0xD8.toByte(), 0xFF.toByte(), 0xE0.toByte(),
+            0x00, 0x10, 0x4A, 0x46, 0x49, 0x46, 0x00, 0x01,
+            0x01, 0x00, 0x00, 0x01
+        )
+        assertTrue(SecureIvRecovery.headerMatchesMagic(firstBlock, jpegMagic))
+    }
+
+    @Test
+    fun jpegFirstBlockFromWrongIvIsRejected() {
+        val garbage = byteArrayOf(
+            0x13, 0x37, 0x42, 0x00, 0x11, 0x22, 0x33, 0x44,
+            0x55, 0x66, 0x77, 0x88.toByte(), 0x99.toByte(), 0xAA.toByte(), 0xBB.toByte(), 0xCC.toByte()
+        )
+        assertFalse(SecureIvRecovery.headerMatchesMagic(garbage, jpegMagic))
+    }
+
+    @Test
+    fun pngFirstBlockWithCorrectSignatureIsAccepted() {
+        val firstBlock = byteArrayOf(
+            0x89.toByte(), 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+            0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52
+        )
+        assertTrue(SecureIvRecovery.headerMatchesMagic(firstBlock, pngMagic))
+    }
+
+    @Test
+    fun pngSignatureDoesNotSatisfyJpegMagic() {
+        val pngBlock = byteArrayOf(
+            0x89.toByte(), 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+            0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52
+        )
+        assertFalse(SecureIvRecovery.headerMatchesMagic(pngBlock, jpegMagic))
+    }
+
+    @Test
+    fun blockShorterThanMagicIsRejected() {
+        assertFalse(SecureIvRecovery.headerMatchesMagic(byteArrayOf(0xFF.toByte(), 0xD8.toByte()), jpegMagic))
+    }
+
+    @Test
+    fun magicForRecognisesJpegAndPngAndIgnoresOthers() {
+        assertArrayEquals(jpegMagic, SecureIvRecovery.magicFor("image/jpeg"))
+        assertArrayEquals(jpegMagic, SecureIvRecovery.magicFor("image/jpg"))
+        assertArrayEquals(pngMagic, SecureIvRecovery.magicFor("image/png"))
+        assertNull(SecureIvRecovery.magicFor("video/webm"))
+        assertNull(SecureIvRecovery.magicFor("image/gif"))
+        assertNull(SecureIvRecovery.magicFor(null))
+    }
+}


### PR DESCRIPTION
Not so short, but needed. I'm still battling some lingering issues that arose from that data corruption issue. My next PR will likely be targeted at eliminating any possibility of said data corruption during the process of de/encrypting media.

Summary:
A stored 16-byte file iv was trusted unconditionally, so a valid-length-but-wrong iv (decrypting to garbage) left the full image permanently undecodable while its thumbnail (separate iv) still loaded - the viewer showed a blank empty_image.

- SecureIvRecovery.validatesImage: force a downsampled decode instead of a header-only inJustDecodeBounds check, so a wrong-iv candidate that only parses the header is rejected rather than persisted
- SecureRepository.load: re-check a 16-byte iv against the format magic bytes and re-recover if it's wrong, instead of trusting size==16
- HorizontalImageList: on secure full-image failure fall back to the working thumbnail rather than the blank empty_image drawable
- add SecureIvHeaderTest for the magic-byte logic