### PR TITLE
fix: prevent stale selection after deleting photos

### DIFF
--- a/app/src/main/java/com/kaii/photos/helpers/grid_management/SelectionManager.kt
+++ b/app/src/main/java/com/kaii/photos/helpers/grid_management/SelectionManager.kt
@@ -55,6 +55,8 @@ class SelectionManager(
 
     private val timeZone = TimeZone.getDefault()
     private var singleSelectMode = false
+    private val selectionLock = Any()
+    private var selectionGeneration = 0L
 
     private var _selection by mutableStateOf<Map<Long, Map<Long, SelectedItem>>>(emptyMap())
     val selection = snapshotFlow { _selection.values.flatMap { it.values } }
@@ -89,9 +91,12 @@ class SelectionManager(
     }
 
     fun clear() {
-        _selection = emptyMap()
-        _sections = emptyList()
-        manualEnable = false
+        synchronized(selectionLock) {
+            selectionGeneration += 1
+            _selection = emptyMap()
+            _sections = emptyList()
+            manualEnable = false
+        }
     }
 
     fun setSingleSelectModeActive(active: Boolean) {
@@ -100,12 +105,12 @@ class SelectionManager(
 
     fun addAll(
         items: List<PhotoLibraryUIModel?>
-    ) = scope.launch(Dispatchers.IO) {
+    ) = launchSelectionMutation { generation ->
         // hardcoded android limit for handling uris
         if (_selection.values.sumOf { it.values.size } >= 2000) {
             // TODO: send a snackbar
 
-            return@launch
+            return@launchSelectionMutation
         }
 
         val snapshot = _selection.toMutableMap()
@@ -136,8 +141,7 @@ class SelectionManager(
             }
         }
 
-        _selection = snapshot
-        _sections = sections
+        publishSelection(generation, snapshot, sections)
     }
 
     fun addMedia(item: MediaStoreData) {
@@ -149,7 +153,7 @@ class SelectionManager(
     fun updateSelection(
         added: List<MediaStoreData>,
         removed: List<MediaStoreData>
-    ) = scope.launch(Dispatchers.IO) {
+    ) = launchSelectionMutation { generation ->
         val snapshot = _selection.toMutableMap()
         val sections = _sections.toMutableList()
 
@@ -192,11 +196,10 @@ class SelectionManager(
         if (snapshot.values.sumOf { it.values.size } >= 2000) {
             // TODO: send a snackbar
 
-            return@launch
+            return@launchSelectionMutation
         }
 
-        _selection = snapshot
-        _sections = sections
+        publishSelection(generation, snapshot, sections)
     }
 
     private fun getKey(item: PhotoLibraryUIModel) =
@@ -226,7 +229,7 @@ class SelectionManager(
         }
     }
 
-    private fun toggleSection(timestamp: Long) = scope.launch(Dispatchers.IO) {
+    private fun toggleSection(timestamp: Long) = launchSelectionMutation { generation ->
         val snapshot = _selection.toMutableMap()
         val sections = _sections.toMutableList()
 
@@ -253,19 +256,18 @@ class SelectionManager(
             sections.add(timestamp)
         }
 
-        _selection = snapshot
-        _sections = sections
+        publishSelection(generation, snapshot, sections)
     }
 
     private fun add(
         item: MediaStoreData,
         key: Long
-    ) = scope.launch(Dispatchers.IO) {
+    ) = launchSelectionMutation { generation ->
         // hardcoded android limit for handling uris
         if (_selection.values.sumOf { it.values.size } >= 2000) {
             // TODO: send a snackbar
 
-            return@launch
+            return@launchSelectionMutation
         }
 
         val snapshot = _selection.toMutableMap()
@@ -289,8 +291,29 @@ class SelectionManager(
             sections.add(key)
         }
 
-        _selection = snapshot
-        _sections = sections
+        publishSelection(generation, snapshot, sections)
+    }
+
+    private fun launchSelectionMutation(block: suspend (Long) -> Unit) =
+        currentSelectionGeneration().let { generation ->
+            scope.launch(Dispatchers.IO) {
+                block(generation)
+            }
+        }
+
+    private fun currentSelectionGeneration() = synchronized(selectionLock) {
+        selectionGeneration
+    }
+
+    private fun publishSelection(
+        generation: Long,
+        selection: Map<Long, Map<Long, SelectedItem>>,
+        sections: List<Long>
+    ) = synchronized(selectionLock) {
+        if (generation == selectionGeneration) {
+            _selection = selection
+            _sections = sections
+        }
     }
 
     private fun remove(item: MediaStoreData, key: Long) {

--- a/app/src/test/java/com/kaii/photos/SelectionManagerTest.kt
+++ b/app/src/test/java/com/kaii/photos/SelectionManagerTest.kt
@@ -1,0 +1,180 @@
+package com.kaii.photos
+
+import com.kaii.photos.database.entities.MediaStoreData
+import com.kaii.photos.helpers.grid_management.MediaItemSortMode
+import com.kaii.photos.helpers.grid_management.SelectionManager
+import com.kaii.photos.helpers.paging.PhotoLibraryUIModel
+import com.kaii.photos.mediastore.MediaType
+import io.github.kaii_lb.lavender.immichintegration.Auth
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.TimeZone
+
+class SelectionManagerTest {
+    @Test
+    fun selectionCommitsWhenClearDoesNotIntervene() = runBlocking {
+        val lookup = DelayedLookup()
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val manager = selectionManager(scope, lookup)
+        val item = media(id = 1)
+
+        manager.addMedia(item)
+        lookup.awaitRequest()
+        lookup.complete(mapOf(item.id to item.toSelectedItem()))
+        scope.awaitChildren()
+
+        assertEquals(listOf(item.id), manager.selection.first().map { it.id })
+        assertTrue(manager.enabled.first())
+    }
+
+    @Test
+    fun clearRejectsStaleSelectionAndAllowsNewItemAtSamePosition() = runBlocking {
+        val lookup = DelayedLookup()
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val manager = selectionManager(scope, lookup)
+        val deletedItem = media(id = 1)
+        val newItem = media(id = 2)
+
+        manager.addMedia(deletedItem)
+        lookup.awaitRequest()
+        manager.clear()
+        lookup.complete(mapOf(deletedItem.id to deletedItem.toSelectedItem()))
+        scope.awaitChildren()
+
+        assertTrue(manager.selection.first().isEmpty())
+        assertFalse(manager.enabled.first())
+
+        manager.addMedia(newItem)
+        lookup.awaitRequest()
+        lookup.complete(mapOf(newItem.id to newItem.toSelectedItem()))
+        scope.awaitChildren()
+
+        assertEquals(listOf(newItem.id), manager.selection.first().map { it.id })
+        assertTrue(manager.enabled.first())
+    }
+
+    @Test
+    fun clearRejectsStaleSectionSelection() = runBlocking {
+        val lookup = DelayedLookup()
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val manager = selectionManager(scope, lookup)
+        val item = media(id = 1)
+        val section = PhotoLibraryUIModel.Section(
+            title = "Today",
+            timestamp = item.getDateTakenDay(TimeZone.getDefault())
+        )
+
+        manager.toggle(section)
+        lookup.awaitRequest()
+        manager.clear()
+        lookup.complete(mapOf(item.id to item.toSelectedItem()))
+        scope.awaitChildren()
+
+        assertTrue(manager.selection.first().isEmpty())
+        assertFalse(manager.isSelected(section))
+        assertFalse(manager.enabled.first())
+    }
+
+    @Test
+    fun clearRejectsStaleBulkSelection() = runBlocking {
+        val lookup = DelayedLookup()
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val manager = selectionManager(scope, lookup)
+        val item = media(id = 1)
+
+        val selectionJob = manager.updateSelection(added = listOf(item), removed = emptyList())
+        lookup.awaitRequest()
+        manager.clear()
+        lookup.complete(mapOf(item.id to item.toSelectedItem()))
+        selectionJob.join()
+
+        assertTrue(manager.selection.first().isEmpty())
+        assertFalse(manager.enabled.first())
+    }
+
+    @Test
+    fun clearRejectsStaleRangeSelection() = runBlocking {
+        val lookup = DelayedLookup()
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val manager = selectionManager(scope, lookup)
+        val item = media(id = 1)
+
+        val selectionJob = manager.addAll(items = listOf(item.toUiModel()))
+        lookup.awaitRequest()
+        manager.clear()
+        lookup.complete(mapOf(item.id to item.toSelectedItem()))
+        selectionJob.join()
+
+        assertTrue(manager.selection.first().isEmpty())
+        assertFalse(manager.enabled.first())
+    }
+
+    private fun selectionManager(scope: CoroutineScope, lookup: DelayedLookup) = SelectionManager(
+        sortMode = MediaItemSortMode.DateTaken,
+        scope = scope,
+        getMediaInDate = { _, _ -> lookup.getMedia() }
+    )
+
+    private suspend fun CoroutineScope.awaitChildren() {
+        coroutineContext[Job]?.children?.toList()?.joinAll()
+    }
+
+    private fun media(id: Long) = MediaStoreData(
+        id = id,
+        uri = "content://media/$id",
+        absolutePath = "/storage/emulated/0/Pictures/$id.jpg",
+        parentPath = "/storage/emulated/0/Pictures",
+        displayName = "$id.jpg",
+        dateTaken = 1_700_000_000,
+        dateModified = 1_700_000_000,
+        mimeType = "image/jpeg",
+        type = MediaType.Image,
+        immichUrl = null,
+        hash = null,
+        size = 1,
+        favourited = false,
+        duration = null
+    )
+
+    private fun MediaStoreData.toSelectedItem() = SelectionManager.SelectedItem(
+        id = id,
+        uri = uri,
+        immichUrl = immichUrl,
+        isImage = type == MediaType.Image,
+        absolutePath = absolutePath,
+        parentPath = parentPath
+    )
+
+    private fun MediaStoreData.toUiModel() = object : PhotoLibraryUIModel.MediaImpl {
+        override val item = this@toUiModel
+        override val auth: Auth
+            get() = error("Not used by SelectionManager")
+        override val endpoint: String? = null
+    }
+
+    private class DelayedLookup {
+        private val requests = Channel<Unit>(Channel.UNLIMITED)
+        private val responses = Channel<Map<Long, SelectionManager.SelectedItem>>(Channel.UNLIMITED)
+
+        suspend fun getMedia(): Map<Long, SelectionManager.SelectedItem> {
+            requests.send(Unit)
+            return responses.receive()
+        }
+
+        suspend fun awaitRequest() = requests.receive()
+
+        suspend fun complete(media: Map<Long, SelectionManager.SelectedItem>) {
+            responses.send(media)
+        }
+    }
+}


### PR DESCRIPTION
Give `SelectionManager` an internal selection generation that advances whenever `clear()` invalidates the current selection session. Long-press selection in the main photo grid can retain the identity of media that was just deleted, so a quick long press at the vacated position starts Android drag-and-drop for the deleted selection instead of selecting the current item.

**Tests**

- Start a normal single-item selection and allow its media lookup to finish:
  the item becomes selected and selection mode remains enabled.
- Pause a single-item selection after it starts, call `clear()`, then resume
  the pending work: the deleted item is not restored and selection mode
  remains disabled.

Fixes #276
